### PR TITLE
Handle no-capture hunters with random codes

### DIFF
--- a/app/pages/sorteig.py
+++ b/app/pages/sorteig.py
@@ -90,7 +90,7 @@ with st.expander("Columnes del fitxer de resultats"):
     st.markdown(
         """
         El CSV resultants inclou, per a cada `ID`:
-        - Per a cada codi de sorteig, la posició on s'ha adjudicat la captura. Si el caçador estava inscrit i no ha obtingut plaça apareix `0`; si no estava inscrit el valor és buit.
+        - Per a cada codi de sorteig, la posició on s'ha adjudicat la captura. Si el caçador estava inscrit i no ha obtingut plaça apareix un codi `s1`, `s2`, ... amb l'ordre dels no adjudicats; si no estava inscrit el valor és buit.
         - Les columnes `Tipus_<codi>` indiquen el tipus de captura assignat en cada sorteig.
         - `Nou_Anys_sense_captura` i `Nova_prioritat` amb els valors resultants després de tots els sortejos.
         """


### PR DESCRIPTION
## Summary
- assign random `sX` codes to hunters participating without capture
- explain new codes in results file help text
- treat `sX` values as no capture when updating totals

## Testing
- `python -m py_compile app/utils/draw_logic.py app/pages/sorteig.py`

------
https://chatgpt.com/codex/tasks/task_e_688a5074a6948320a36d1d687058d4e9