### PR TITLE
Handle numeric conversion for Quantitat

### DIFF
--- a/app/utils/draw_logic.py
+++ b/app/utils/draw_logic.py
@@ -230,6 +230,15 @@ def processar_sorteigs(df1, df2, config, especie, seed):
     import pandas as pd
     rng = np.random.RandomState(seed) if seed is not None else np.random.RandomState()
 
+    # Ensure numeric quantities in configuration
+    config = config.copy()
+    if "Quantitat" in config.columns:
+        config["Quantitat"] = (
+            pd.to_numeric(config["Quantitat"], errors="coerce")
+            .fillna(0)
+            .astype(int)
+        )
+
     ids_totals = df2["ID"].unique()
     if especie == "Isard":
         extra = df1.loc[df1["Modalitat"].notna() & ~df1["ID"].isin(ids_totals), "ID"]


### PR DESCRIPTION
## Summary
- avoid crashing when config Quantitat values contain non-numeric strings

## Testing
- `python -m py_compile app/utils/draw_logic.py app/pages/sorteig.py app/pages/dashboard.py run_app.py`

------
https://chatgpt.com/codex/tasks/task_e_688a60650b3c8320b7152413eda9780c